### PR TITLE
Add project scaffold skill

### DIFF
--- a/rules/skills/INDEX.md
+++ b/rules/skills/INDEX.md
@@ -62,6 +62,7 @@
 - [知识飞轮设计模式](./workflow_knowledge_flywheel.md) — 笨数据+笨方法+笨模型=精知识
 - [视频下载与语音识别工作流](./workflow_bilibili_whisper_transcription.md) — Bilibili/YouTube 视频处理
 - [延时执行技能](./delayed_execution.md) ⚙️ — 定时任务：sleep + 后台执行，或 OpenCode API 智能任务
+- [项目脚手架与重整](./project_scaffold.md) ✅ — 把散装目录升级成标准项目结构：`docs/`、`src/`、`scripts/`、`tests/`、`AGENTS.md` 与独立 git
 
 ### BestPractice（最佳实践）
 

--- a/rules/skills/project_scaffold.md
+++ b/rules/skills/project_scaffold.md
@@ -1,0 +1,233 @@
+# 项目脚手架与重整 Skill
+
+把一个临时目录、散装脚本目录，或结构不完整的小项目，整理成可长期维护的标准项目形态。
+
+**触发词**: "bootstrap 一个 project"、"scaffold 一个 project"、"把这个目录整理成项目"、"补齐 PRD/RFC/working"、"给这个目录单独建 git repo"
+
+---
+
+## 1. 适用场景
+
+当一个目录已经不再是一次性脚本，而是会被反复修改、需要多轮 AI 接手、需要测试、需要频繁提交时，就应该升级成标准项目结构。
+
+典型信号：
+
+- 目录里已经有 2 个以上脚本/模块
+- 用户明确要求补文档、加 tests、频繁 commit
+- 未来会继续迭代，不只是一次性任务
+- 需要独立 git 历史，不能一直混在 workspace 大仓库里
+
+---
+
+## 2. 目标结构
+
+最小推荐结构：
+
+```text
+project_root/
+├── AGENTS.md
+├── .gitignore
+├── docs/
+│   ├── prd.md
+│   ├── rfc.md
+│   ├── working.md
+│   └── test.md
+├── src/
+├── scripts/
+├── tests/
+└── <compat wrappers / entrypoints if needed>
+```
+
+### 每个目录/文件的职责
+
+- `docs/prd.md`: 讲目标、用户、需求、成功标准
+- `docs/rfc.md`: 讲架构、边界、关键设计决策、迁移策略
+- `docs/working.md`: 两部分
+  - `## Changelog`: 每天一个小标题，下面用简单 bullet 记当天改了什么
+  - `## Lessons Learned`: 记录坑、约束、后续 agent 不该重复犯的错
+- `docs/test.md`: 测试策略，写清 unit / integration / e2e 覆盖目标
+- `src/`: 可复用源码，尽量放模块，不放面向用户的 shell 入口
+- `scripts/`: 面向用户直接跑的 CLI、shell entrypoints、运维脚本
+- `tests/`: 单测、集成测试、未来 e2e
+- `AGENTS.md`: 这个项目自己的局部规则，尤其提醒更新 `working.md`、频繁 commit、环境要求
+
+### 当前 workspace 推荐的前后端脚手架
+
+如果项目明确是一个小到中等规模的 Web 应用，而且目标是**先快速做出可运行产品，再逐步演进**，当前 workspace 的默认推荐是：
+
+- **后端**：FastAPI
+- **前端**：React + Vite + TypeScript
+- **本地存储**：优先 SQLite（除非用户明确要求更重的数据库）
+- **生产部署**：先把前端 build 产物直接交给 FastAPI 统一 serve
+
+推荐目录：
+
+```text
+project_root/
+├── AGENTS.md
+├── .gitignore
+├── docs/
+├── frontend/
+│   ├── src/
+│   ├── package.json
+│   └── vite.config.ts
+├── scripts/
+│   ├── start_backend.sh
+│   ├── start_frontend.sh
+│   └── build_frontend.sh
+├── src/
+│   └── <python package>
+├── tests/
+└── pyproject.toml
+```
+
+补充说明：
+
+1. `frontend/` 独立维护 React/Vite 工程
+2. `src/` 只放后端 Python 包，不把后端逻辑塞进根目录脚本
+3. `scripts/` 提供面向人和 agent 的稳定入口，避免每次都现场猜命令
+4. 生产模式优先走“FastAPI 同源托管前端 build”，这样 auth、prefix、部署路径都更容易保持一致
+
+### 前后端项目至少要补齐的 3 个脚本
+
+如果是 FastAPI + React 项目，默认应补齐：
+
+1. `scripts/start_backend.sh`
+   - 激活 `.venv`
+   - 设置后端环境变量
+   - 启动 `uvicorn`
+2. `scripts/start_frontend.sh`
+   - 设置前端 dev 所需环境变量
+   - 启动 `npm run start_dev_server` 或等价命令
+3. `scripts/build_frontend.sh`
+   - 设置构建时 base path / token / api base 等变量
+   - 执行 `npm run build`
+
+不要把这些命令只写在 README 里。脚本本身就是 contract。
+
+### URL prefix / root path 的默认建议
+
+如果项目将来可能挂在子路径（例如 `/foo/bar`）下，必须在脚手架阶段就统一配置来源。
+
+默认建议：
+
+- 用**一个环境变量**统一驱动，比如 `APP_ROOT_PATH`
+- 后端读取它并映射到 FastAPI `root_path`
+- 前端读取它并映射到 Vite `base` 与 React Router `basename`
+- `scripts/start_backend.sh`、`scripts/start_frontend.sh`、`scripts/build_frontend.sh` 都从这个单一变量派生各自配置
+
+不要让后端、前端、反向代理分别维护三套前缀字符串。那样几乎一定会在部署到子路径时坏掉。
+
+---
+
+## 3. 推荐执行顺序
+
+### Phase 1：先确认边界
+
+先判断三件事：
+
+1. 这个目录是不是已经值得成为独立项目
+2. 用户是否允许重整目录结构
+3. 是否需要单独 nested git repo
+
+如果用户没有授权重整现有项目结构，不要擅自大搬家。
+
+### Phase 2：先立骨架，再迁代码
+
+推荐顺序：
+
+1. 建 `docs/ / src/ / scripts/ / tests/`
+2. 写 `AGENTS.md`、`.gitignore`
+3. 先写 `prd.md` / `rfc.md` / `test.md`
+4. 再把代码迁到 `src/`，把可执行入口放进 `scripts/`
+5. 最后补 `working.md`
+
+不要一边大改代码一边临时想目录结构。先把骨架立起来，后面的改动才会更稳。
+
+### Phase 3：保兼容入口
+
+如果外部已有 cron、脚本、用户习惯路径，不要第一刀就砍掉。优先保留兼容 wrapper：
+
+- 老路径保留成 thin wrapper
+- 新逻辑进 `src/` / `scripts/`
+
+这样可以先完成重构，再逐步迁移调用方。
+
+---
+
+## 4. Git 策略
+
+如果目录需要长期维护，而且和 workspace 大仓库的历史无关，优先单独 `git init`。
+
+推荐提交切法：
+
+1. **scaffold commit**
+   - docs/AGENTS/.gitignore/基础目录
+2. **implementation commit**
+   - 真正的代码迁移、模块化、测试
+3. **validation commit**
+   - `working.md` 记录、测试结果、回填或手工验证结果
+
+不要把大重构、文档补齐、测试修复、历史 backfill 全塞进一个 commit。
+
+---
+
+## 5. AGENTS.md 最少要写什么
+
+项目局部 `AGENTS.md` 至少要覆盖：
+
+1. 项目结构说明
+2. `working.md` 更新要求
+3. 频繁 commit 的要求
+4. 本项目 Python / Node / shell 环境约束
+5. 任何不能破坏的兼容约束
+
+如果这个文件不写，后续 agent 很容易把项目重新写回临时脚本堆。
+
+---
+
+## 6. working.md 维护要求
+
+### Changelog
+
+- 每天一个日期小标题
+- 每个 bullet 只写一个改动
+- 不用 nested bullet points
+- 不要写空话，比如“做了一些优化”
+
+### Lessons Learned
+
+只写真会帮助后续 agent 避坑的内容，例如：
+
+- 哪些文件是兼容 wrapper，不能直接删
+- 哪些输出格式是外部依赖的 contract
+- 哪些本地数据源看起来像主数据源，其实只是辅助索引
+
+---
+
+## 7. test.md 应该写什么
+
+至少要说明：
+
+- unit tests 覆盖哪些纯逻辑
+- integration tests 依赖哪些本地数据或服务
+- e2e 是否存在，如果暂时没有，也要写清楚为什么没有
+- 手工验证要看什么 artifact
+
+`test.md` 的价值不是重复 pytest 命令，而是让后续 agent 知道“什么算验证完成”。
+
+---
+
+## 8. 重整已有项目时的硬规则
+
+1. 没有用户许可，不要擅自大规模迁目录
+2. 先建骨架，再搬代码
+3. 先保兼容，再删旧入口
+4. 每次阶段性完成后更新 `working.md`
+5. 每个阶段都要有可运行或可验证状态
+
+---
+
+## 9. 一句话判断标准
+
+如果一个目录未来还会被继续改，而且希望不同 AI/人能低成本接手，那它就不该继续保持“散装脚本目录”状态，而应该尽快升级成上面这套项目骨架。


### PR DESCRIPTION
## Summary
- Add the project scaffold and restructuring skill to `rules/skills/`.
- Register the skill in the Workflow section of the skills index.
- Reviewed the copied skill for private data; only generic config terms such as `.venv` and `token / api base` appear.

## Verification
- `GIT_MASTER=1 git diff --check`
- Manual privacy scan with `rg` over changed skill/index files
- Markdown LSP diagnostics unavailable because no `.md` LSP server is configured