### PR TITLE
Add public skill ecosystem directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ cd context-infrastructure
 
 详细步骤见 [`setup_guide.md`](setup_guide.md)。
 
+如果你想把它扩展成更完整的工作系统，可以看 [`docs/SKILL_ECOSYSTEM.md`](docs/SKILL_ECOSYSTEM.md)。那里列了一组可单独安装的 public skill repo，例如 Web 搜索、邮件、OpenCode、PPTX、社交媒体、支付分析和本地 process launcher。`context-infrastructure` 保持轻量；完整能力通过独立 repo 按需安装。
+
 ---
 
 ## 目录结构
@@ -31,7 +33,8 @@ context-infrastructure/
 ├── .env.example                 # 环境变量模板
 │
 ├── docs/
-│   └── CRONTAB.md               # 定时任务配置指南（时间线 + 示例 crontab）
+│   ├── CRONTAB.md               # 定时任务配置指南（时间线 + 示例 crontab）
+│   └── SKILL_ECOSYSTEM.md       # 可单独安装的 public skill repo 目录
 │
 ├── rules/
 │   ├── SOUL.md                  # AI 的身份和行为基调（模板）

--- a/docs/SKILL_ECOSYSTEM.md
+++ b/docs/SKILL_ECOSYSTEM.md
@@ -1,0 +1,47 @@
+# Public Skill Ecosystem
+
+`context-infrastructure` 自带的 `rules/skills/` 是 starter set：它展示 skill 应该如何被组织、索引和调用。更完整的能力不应该全部复制进这个仓库，而是通过独立 public skill repo 安装。这样做有两个好处：第一，每个 skill repo 可以保留自己的 README、CLI、测试和发布节奏；第二，用户 workspace 里的私有 alias、路径、token 和业务上下文可以留在本地 overlay，不会混进 public repo。
+
+这个页面同时给人和 AI 看。人可以用它发现还可以安装哪些能力；AI 可以按这里的安装协议，把某个 public skill repo 接入目标 workspace。
+
+## 安装协议
+
+把下面这段话连同目标 repo URL 交给你的 coding agent：
+
+```text
+Install this public skill repo into my workspace:
+<GitHub URL>
+
+Start from my workspace AGENTS.md or CLAUDE.md. Follow any WORKSPACE.md or skills/INDEX.md routing rules. Clone or vendor the repo under an appropriate project directory. Expose exactly one root skill to my global skill index or agent instructions. Keep private aliases, local paths, credentials, endpoint defaults, and business context in a local overlay, not in the public repo.
+```
+
+安装完成后，workspace 通常会形成两层：public repo 负责通用技术 contract，本地 `rules/skills/` 或 `.env` 负责私有配置。例如 iMessage public repo 只提供 send-only CLI，本地 overlay 才保存联系人 alias；Stripe public repo 只提供只读分析 contract，本地 overlay 才保存具体业务归因。
+
+## 推荐安装的 public skill repos
+
+| 方向 | Repo | 能力 |
+|---|---|---|
+| Web search | [tavily-skill](https://github.com/grapeot/tavily-skill) | Tavily search/extract CLI，给 agent 稳定 JSON 输出 |
+| Documents | [gdocs-skill](https://github.com/grapeot/gdocs-skill) | Google Docs 创建、搜索、修改、分享，支持 Markdown 和 tab |
+| Email | [outlook_skill](https://github.com/grapeot/outlook_skill) | Outlook.com 邮件下载、归档、Markdown 渲染、发送和日历邀请 |
+| Email | [resend_email_skill](https://github.com/grapeot/resend_email_skill) | Resend 自定义域名发信、收件读取、Markdown 导出和附件检查 |
+| Messaging | [imessage_skill](https://github.com/grapeot/imessage_skill) | macOS iMessage send-only CLI；联系人 alias 放本地 overlay |
+| Agent operations | [opencode_skill](https://github.com/grapeot/opencode_skill) | OpenCode job 提交、批量任务、SQLite 数据维护和 archive |
+| Agent operations | [process-launcher](https://github.com/grapeot/process-launcher) | 本地 HTTP process launcher，适合 TCC / GUI 权限桥接 |
+| Usage analytics | [ai_usage_dashboard](https://github.com/grapeot/ai_usage_dashboard) | 多平台 AI token usage、成本估算、本地 dashboard 和 E1002 JSON |
+| Social / growth | [typefully-twitter-skill](https://github.com/grapeot/typefully-twitter-skill) | Typefully 发帖、账号指标和 X/Twitter 单帖 analytics |
+| Payments / growth | [stripe-skill](https://github.com/grapeot/stripe-skill) | Stripe 只读 finance / sales analytics，live tests 默认 opt-in |
+| Media | [online-media-skill](https://github.com/grapeot/online-media-skill) | 在线媒体下载、ASR artifact、query pack 和 source identification 工作流 |
+| Slides | [pptx.skill](https://github.com/grapeot/pptx.skill) | AI-first PPTX 读取、编辑和渲染 |
+| Images | [tiff-icc-profile](https://github.com/grapeot/tiff-icc-profile) | 给未标记 TIFF 嵌入 ICC profile，常用于 DaVinci still workflow |
+| Health | [health-quantification](https://github.com/grapeot/health-quantification) | Apple Health / 手动记录 → SQLite → CLI → AI 分析 |
+| Coffee | [roest-analysis](https://github.com/grapeot/roest-analysis) | Roest roast log 抓取与分析 |
+| Intake | [intake-skill](https://github.com/grapeot/intake-skill) | Voice memos / intake workflow 的 public-ready skill |
+
+## 选择原则
+
+如果一个能力需要完整 CLI、测试、fixtures 或长期维护，把它做成独立 repo。`context-infrastructure` 只链接它，不复制它。这样用户可以按需安装，不会让 starter workspace 变成巨大的工具合集。
+
+如果一个能力只是通用工作方法，例如深度调研、并行 subagent、分析写作、skill 写作、项目脚手架，可以留在本仓库的 `rules/skills/`。这些文件是 reference implementation 的核心，clone 后就能阅读和改造。
+
+如果一个能力依赖私人数据、私人账号或业务上下文，把通用部分放 public repo，把私人部分留在用户自己的 workspace overlay。不要把真实联系人、服务器、路径、API key、客户名、交易数据或使用记录写进 public repo。

--- a/docs/working.md
+++ b/docs/working.md
@@ -1,0 +1,8 @@
+# Working Log
+
+## 2026-05-25
+
+- Added a human- and agent-readable public skill ecosystem index at `docs/SKILL_ECOSYSTEM.md`.
+- Linked the ecosystem index from `README.md`, `setup_guide.md`, and `rules/skills/INDEX.md` so users can discover standalone skill repos without loading every repo into the starter skill index.
+- Kept the model as public repo + private workspace overlay: public repos hold generic CLI contracts and tests; local workspaces hold aliases, paths, endpoints, credentials, and business context.
+- Updated `rules/skills/project_scaffold.md` with the public skill repo installation convention: loose Markdown-based install, one root/router skill per repo, and private overlays outside the public repo.

--- a/rules/skills/INDEX.md
+++ b/rules/skills/INDEX.md
@@ -4,6 +4,7 @@
 
 - **想使用某个能力** → 浏览下方分类，找到对应的 skill 文件
 - **想添加新 skill** → 参考现有文件格式，添加到对应分类
+- **想安装更多工具型能力** → 看 [`../../docs/SKILL_ECOSYSTEM.md`](../../docs/SKILL_ECOSYSTEM.md)，那里列出可单独安装的 public skill repo
 
 ---
 
@@ -21,9 +22,13 @@
 - ⚙️ Send Email — 需要 Gmail App Password
 - ⚙️ Delayed Execution — 适配你自己的工具路径
 
+### Tier 3: 独立 public skill repos（按需安装）
+- 🔧 Tavily、Google Docs、Outlook、Resend、OpenCode、Process Launcher、PPTX、Typefully、Stripe 等能力见 [`docs/SKILL_ECOSYSTEM.md`](../../docs/SKILL_ECOSYSTEM.md)
+
 ### 说明
 ✅ = 最多 15 分钟即可使用
 ⚙️ = 需要额外配置，不配不影响核心功能
+🔧 = 独立 repo，按需安装到你的 workspace
 
 ---
 

--- a/rules/skills/project_scaffold.md
+++ b/rules/skills/project_scaffold.md
@@ -54,6 +54,10 @@
 
 5. **如果项目包含 skill**，必须拆成两层。公开 repo 里放技术实现（CLI、测试、API contract、skill 的工作流文档），私有联系人、私有路由、私有 handle 放在 workspace 全局 skill 目录（如 `rules/skills/`）或私有 `.env` 中。公开 repo 的 skill 文档里要写清楚「私有 alias 在哪找」。参考 `adhoc_jobs/resend_email_skill/`（公开技术 skill）和 `rules/skills/imessage.md`（私有联系人路由）的拆分方式。
 
+   Public skill repos should assume loose Markdown-based installation, not vendor-specific skill packaging. The README must explain how a human can hand the GitHub URL to Codex, Claude Code, Cursor, OpenCode, or another coding agent and ask it to install the skill. The AI installer should start from the target workspace's `AGENTS.md` or `CLAUDE.md`, follow any routing file such as `WORKSPACE.md`, and then add the public repo's root skill to the workspace discovery chain. If the workspace has `rules/skills/INDEX.md` or `skills/INDEX.md`, update that index; otherwise add a short pointer in `AGENTS.md` or `CLAUDE.md`.
+
+   If the public repo contains multiple skills, expose exactly one root/router skill to the global workspace level. Use that root skill to link to focused local files inside the repo. Do not symlink every focused skill globally; that makes discovery noisy and makes private/public overlays harder to reason about.
+
 6. **完成后的隐私检查**。在最终验证阶段（Phase 4），必须跑一次隐私扫描：
 
    ```bash

--- a/setup_guide.md
+++ b/setup_guide.md
@@ -64,7 +64,13 @@
 
 将新 skill 添加到 `rules/skills/INDEX.md` 对应分类。
 
-### 2c. 关于 Axioms（公理）
+### 2c. 安装外部 public skill repo
+
+`rules/skills/` 里的内容是 starter set，不需要把所有能力都复制进来。需要更完整的能力时，先看 [`docs/SKILL_ECOSYSTEM.md`](docs/SKILL_ECOSYSTEM.md)。那里列出了一组独立维护的 public skill repo，例如 Tavily、Google Docs、Outlook、Resend、OpenCode、Process Launcher、PPTX、Typefully 和 Stripe。
+
+安装时，把目标 repo URL 交给你的 AI agent，让它从当前 workspace 的 `AGENTS.md` / `WORKSPACE.md` 出发，只暴露一个 root skill。通用技术 contract 留在 public repo；联系人 alias、本地路径、endpoint、token 和业务上下文留在本地 overlay。
+
+### 2d. 关于 Axioms（公理）
 
 `rules/axioms/` 包含 43 条从真实经历中蒸馏的决策原则。这些代表原作者的视角和认知模式，对你有**参考价值**，但不能替代你自己的公理。
 
@@ -165,7 +171,7 @@ python3 periodic_jobs/ai_heartbeat/src/v0/observer.py 2024-01-15
 A：可以用来理解系统的结构，但核心内容代表原作者的视角。你的 axioms 需要从你自己的经历中提炼。参考 `rules/skills/workflow_cognitive_profile_extraction.md` 了解提炼方法。
 
 **Q：skills 能直接用吗？**  
-A：✅ 标记的可以直接用。⚙️ 标记的需要替换配置（endpoint、API key、域名等）。BestPractice 类基本都可以直接用。
+A：✅ 标记的可以直接用。⚙️ 标记的需要替换配置（endpoint、API key、域名等）。BestPractice 类基本都可以直接用。更完整的工具型能力放在独立 public repo 里，见 [`docs/SKILL_ECOSYSTEM.md`](docs/SKILL_ECOSYSTEM.md)。
 
 **Q：observer.py 需要什么依赖？**  
 A：依赖 `opencode_client.py`（OpenCode Server 的客户端封装）。这部分需要你根据自己使用的 AI agent 框架来实现或适配。


### PR DESCRIPTION
## Summary
- Add a human- and agent-readable index of standalone public skill repos.
- Link the ecosystem index from README, setup guide, and the starter skill index.
- Document public skill repo installation conventions in the project scaffold skill.

## Privacy review
- Scanned changed files for personal emails, local absolute paths, private network addresses, token patterns, and secret-manager references.
- Only expected placeholder/privacy-scan examples were present; no real secrets or private data were added.