### PR TITLE
Add PDF to Markdown CLI skill

### DIFF
--- a/rules/skills/bestpractice_pdf_to_markdown.md
+++ b/rules/skills/bestpractice_pdf_to_markdown.md
@@ -22,7 +22,7 @@ OpenDataLoader benchmark 12 个 PDF→Markdown 引擎里 Docling 综合得分最
 
 如果你要在自己的 workspace 里保留引擎对比调研，把调研记录放在项目文档或 `contexts/` 下，并在本 skill 里链接到你的本地报告。
 
-## 怎么用
+## 快速用法
 
 ```bash
 uv pip install --python .venv/bin/python docling
@@ -38,6 +38,14 @@ md = result.document.export_to_markdown()
 
 首次调用会下载约 1 GB 模型权重到 HuggingFace 缓存，之后复用。同一个 `DocumentConverter()` 实例可以连续转多份，不要每份都新建。
 
+也可以直接使用本 skill 自带的 CLI。它把 Docling、LM Studio VLM OCR 和环境检查封装成固定命令，适合 agent 反复调用：
+
+```bash
+source .venv/bin/activate
+python rules/skills/pdf_to_markdown_cli.py doctor --format json
+python rules/skills/pdf_to_markdown_cli.py docling input.pdf --output output.md --format json
+```
+
 ## 验收
 
 - 输出 Markdown 中表格用标准 `| ... |` 语法保留，列对齐
@@ -52,10 +60,127 @@ md = result.document.export_to_markdown()
 
 **venv 里 pip 不存在**。在用 uv 创建的 venv 里通常没装 pip，`venv/bin/python -m pip install` 会报 `No module named pip`。改用 `uv pip install --python .venv/bin/python <pkg>`。
 
-## 适用边界
+## 已知陷阱（续）
 
-不适用：
+**macOS MPS float64 崩溃**。Apple Silicon 上 Docling 的 RT-DETR V2 模型做 layout 检测时会调用 `torch.float64`，MPS 后端不支持，整份 PDF 转换崩溃。workaround：
 
-- 扫描件 / 图片 PDF：docling 自带 OCR 但精度不如专用 OCR。如果纯扫描件，先评估 Tesseract 或商业 API
-- 复杂数学公式：导出 LaTeX 但保真度有限
-- 需要保留页码、页眉页脚的归档场景：docling 默认会清掉这些
+```bash
+PYTORCH_ENABLE_MPS_FALLBACK=1 python -c "
+from docling.document_converter import DocumentConverter
+...
+"
+```
+
+或直接改 `~/.bashrc`/`.zshrc` 加 `export PYTORCH_ENABLE_MPS_FALLBACK=1`。如果仍然失败（已知特定版本组合下 MPS fallback 也不生效），切换到 VLM OCR 路径。
+
+## 适用边界与路径选择
+
+| PDF 类型 | 首选 | fallback | 不推荐 |
+|---------|------|----------|--------|
+| 文本 PDF（Office/WPS 导出、LaTeX） | Docling | — | MarkItDown |
+| 扫描件（英文为主） | Docling（自带 OCR） | Tesseract | — |
+| 扫描件/图片 PDF（中文为主、图文混排、pitch deck） | **LM Studio VLM OCR** | Tesseract（精度低） | Docling（MPS float64 风险） |
+| 复杂数学公式 | Docling（导出 LaTeX） | 人工校对 | — |
+
+## CLI：PDF→Markdown
+
+CLI 文件位于 `rules/skills/pdf_to_markdown_cli.py`。它不是独立服务，不保存状态；每次运行只读取输入 PDF，写出 Markdown，并把结果摘要输出到 stdout。进度和错误写到 stderr。
+
+### 前置环境
+
+在 workspace 根目录使用 `.venv`：
+
+```bash
+source .venv/bin/activate
+uv pip install docling
+```
+
+如果要走 LM Studio VLM OCR fallback，还需要：
+
+```bash
+uv pip install pdf2image pillow requests
+```
+
+`pdf2image` 依赖系统里的 Poppler。macOS 可用：
+
+```bash
+brew install poppler
+```
+
+LM Studio 需要手动打开并加载视觉模型。默认 API 是 `http://127.0.0.1:1234/v1`，默认模型名是 `qwen/qwen3.5-35b-a3b`。
+
+### Doctor
+
+先跑 doctor 看本地环境是否齐全：
+
+```bash
+python rules/skills/pdf_to_markdown_cli.py doctor --format json
+```
+
+需要检查 LM Studio 是否在线、目标模型是否已加载时：
+
+```bash
+python rules/skills/pdf_to_markdown_cli.py doctor --check-lmstudio --format json
+```
+
+### Docling 路径（默认首选）
+
+普通文本 PDF、LaTeX PDF、Office 导出的 PDF，优先走 Docling：
+
+```bash
+python rules/skills/pdf_to_markdown_cli.py docling input.pdf --output output.md --format json
+```
+
+等价的通用命令：
+
+```bash
+python rules/skills/pdf_to_markdown_cli.py convert input.pdf --engine docling --output output.md --format json
+```
+
+### LM Studio VLM OCR 路径
+
+当 Docling 对中文扫描件、图片 PDF、pitch deck 的 OCR 明显失败时，再显式切换到 VLM OCR：
+
+```bash
+python rules/skills/pdf_to_markdown_cli.py vlm-ocr input.pdf \
+  --output output.md \
+  --model qwen/qwen3.5-35b-a3b \
+  --timeout 300 \
+  --format json
+```
+
+常用调参：
+
+- `--dpi 150`：图片太大、模型响应慢或输出漂移时降低 DPI
+- `--start-page N --end-page M`：只处理部分页面，先验证再跑整份
+- `--api-base http://127.0.0.1:1234/v1`：LM Studio 不在默认端口时显式指定
+
+VLM OCR 输出带 `=== PAGE N ===` 分页标记。大 PDF 每页约 30-60 秒，17 页 pitch deck 约 10-15 分钟，取决于模型和机器负载。
+
+### CLI 验收
+
+- `--format json` 时 stdout 必须是可解析 JSON
+- `doctor` 能准确报告缺失依赖或 LM Studio 不在线
+- Docling 输出应保留标题层级和 Markdown 表格
+- VLM OCR 输出应保留原文语言，不总结、不翻译，并包含页码分隔
+
+## LM Studio VLM OCR 原理
+
+当 Docling 和 Tesseract 都处理不好时（中文 pitch deck、图像密集的幻灯片），用本地视觉模型做 OCR。CLI 位于 `rules/skills/pdf_to_markdown_cli.py`：
+
+```bash
+source .venv/bin/activate
+python rules/skills/pdf_to_markdown_cli.py vlm-ocr input.pdf --output output.md --timeout 300
+```
+
+前提：LM Studio 在本地运行（默认 `http://127.0.0.1:1234`），已加载视觉模型。默认模型为 `qwen/qwen3.5-35b-a3b`，该模型对中英文混排 pitch deck 的 OCR 效果远超 Tesseract。
+
+脚本会逐页渲染 PDF 为图片（200 DPI），通过 LM Studio 的 `/v1/chat/completions` 端点逐页喂图，输出带 `=== PAGE N ===` 分页的 Markdown。prompt 为通用 OCR，不做财务 schema 约束。大 PDF 每页约 30-60 秒，整份 17 页 pitch deck 约 10-15 分钟。
+
+注意：LM Studio 的 VLM API 是 OpenAI-compatible 的，不是专用 OCR API。输出质量取决于模型能力和 prompt。如果某页 OCR 结果明显偏离原图，降低 DPI（`--dpi 150`）或缩短 prompt 指令再试。
+
+## 仍需人工复核的场景
+
+- 复杂数学公式：Docling 可以导出 LaTeX，但保真度有限
+- 需要保留页码、页眉页脚的归档场景：Docling 默认会清掉这些，VLM OCR 也可能改写布局
+- 法律、财务、医疗等高风险文档：转换后必须抽样回查原 PDF

--- a/rules/skills/pdf_to_markdown_cli.py
+++ b/rules/skills/pdf_to_markdown_cli.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+"""PDF to Markdown helper CLI for AI agents.
+
+The default path uses Docling for text PDFs. The VLM path renders pages and
+calls a local LM Studio OpenAI-compatible vision model for scan-heavy PDFs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import importlib.util
+import io
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_API_BASE = "http://127.0.0.1:1234/v1"
+DEFAULT_MODEL = "qwen/qwen3.5-35b-a3b"
+DEFAULT_DPI = 200
+DEFAULT_TIMEOUT = 300
+
+OCR_SYSTEM_PROMPT = (
+    "You are a precise OCR assistant. Given a PDF page image, extract ALL "
+    "visible text faithfully. Output Markdown with headings, paragraphs, "
+    "tables, and structured formatting when appropriate. Do NOT summarize or "
+    "translate. Preserve the original language exactly. Include key numbers, "
+    "labels, captions, and table structure."
+)
+
+OCR_USER_PROMPT = (
+    "Extract all visible text from this PDF page as Markdown. Output only the "
+    "Markdown content, no extra commentary."
+)
+
+
+class CliError(Exception):
+    """User-facing command error."""
+
+
+def has_module(module_name: str) -> bool:
+    return importlib.util.find_spec(module_name) is not None
+
+
+def default_output_path(pdf_path: Path, suffix: str = ".md") -> Path:
+    return pdf_path.with_suffix(suffix)
+
+
+def normalize_api_base(api_base: str) -> str:
+    return api_base.rstrip("/")
+
+
+def encode_image(image: Any) -> str:
+    image_module_missing = not hasattr(image, "convert")
+    if image_module_missing:
+        raise CliError("Image object does not support PIL-style conversion")
+
+    buf = io.BytesIO()
+    image.convert("RGB").save(buf, format="JPEG", quality=95)
+    return base64.b64encode(buf.getvalue()).decode("ascii")
+
+
+def build_vlm_payload(image_b64: str, model: str) -> dict[str, Any]:
+    return {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": [{"type": "text", "text": OCR_SYSTEM_PROMPT}]},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{image_b64}"}},
+                    {"type": "text", "text": OCR_USER_PROMPT},
+                ],
+            },
+        ],
+        "temperature": 0,
+        "max_tokens": 16384,
+    }
+
+
+def extract_message_text(response_data: dict[str, Any]) -> str:
+    choices = response_data.get("choices") or []
+    if not choices:
+        raise CliError(f"No choices in LM Studio response: {response_data}")
+
+    message = choices[0].get("message") or {}
+    content = message.get("content")
+    if isinstance(content, str) and content.strip():
+        return content
+
+    reasoning_content = message.get("reasoning_content")
+    if isinstance(reasoning_content, str) and reasoning_content.strip():
+        return reasoning_content
+
+    if isinstance(content, list):
+        text_parts = [part.get("text", "") for part in content if isinstance(part, dict)]
+        joined = "".join(text_parts).strip()
+        if joined:
+            return joined
+
+    raise CliError(f"LM Studio response did not contain text content: {response_data}")
+
+
+def validate_page_range(start_page: int, end_page: int | None) -> None:
+    if start_page < 1:
+        raise CliError("--start-page must be >= 1")
+    if end_page is not None and end_page < start_page:
+        raise CliError("--end-page must be >= --start-page")
+
+
+def write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def convert_with_docling(pdf_path: Path) -> str:
+    if not has_module("docling"):
+        raise CliError("Missing dependency: docling. Install with `uv pip install docling`.")
+
+    from docling.document_converter import DocumentConverter  # type: ignore
+
+    converter = DocumentConverter()
+    result = converter.convert(str(pdf_path))
+    return result.document.export_to_markdown()
+
+
+def render_pdf_pages(pdf_path: Path, dpi: int, start_page: int, end_page: int | None) -> list[Any]:
+    if not has_module("pdf2image"):
+        raise CliError("Missing dependency: pdf2image. Install with `uv pip install pdf2image`.")
+
+    from pdf2image import convert_from_path  # type: ignore
+
+    validate_page_range(start_page, end_page)
+    kwargs: dict[str, Any] = {"dpi": dpi, "first_page": start_page}
+    if end_page is not None:
+        kwargs["last_page"] = end_page
+    return convert_from_path(str(pdf_path), **kwargs)
+
+
+def ocr_page_via_lmstudio(image: Any, api_base: str, model: str, timeout: int) -> str:
+    if not has_module("requests"):
+        raise CliError("Missing dependency: requests. Install with `uv pip install requests`.")
+
+    import requests  # type: ignore
+
+    payload = build_vlm_payload(encode_image(image), model)
+    response = requests.post(
+        normalize_api_base(api_base) + "/chat/completions",
+        headers={"Content-Type": "application/json"},
+        json=payload,
+        timeout=timeout,
+    )
+    response.raise_for_status()
+    return extract_message_text(response.json())
+
+
+def convert_with_vlm(
+    pdf_path: Path,
+    api_base: str,
+    model: str,
+    dpi: int,
+    timeout: int,
+    start_page: int,
+    end_page: int | None,
+) -> str:
+    pages = render_pdf_pages(pdf_path, dpi, start_page, end_page)
+    page_count = len(pages)
+    md_parts = [f"OCR_TOTAL_PAGES: {page_count}\n"]
+
+    for index, image in enumerate(pages):
+        page_num = start_page + index
+        print(f"OCR page {page_num} ({index + 1}/{page_count})", file=sys.stderr, flush=True)
+        text = ocr_page_via_lmstudio(image, api_base, model, timeout)
+        md_parts.append(f"=== PAGE {page_num} ===\n\n{text}\n")
+
+    return "\n\n".join(md_parts)
+
+
+def lmstudio_models(api_base: str, timeout: int = 10) -> tuple[bool, list[str], str | None]:
+    if not has_module("requests"):
+        return False, [], "Missing dependency: requests"
+
+    import requests  # type: ignore
+
+    try:
+        response = requests.get(normalize_api_base(api_base) + "/models", timeout=timeout)
+        response.raise_for_status()
+        data = response.json()
+    except Exception as exc:  # pragma: no cover - exact exception depends on requests
+        return False, [], str(exc)
+
+    models = [item.get("id", "") for item in data.get("data", []) if item.get("id")]
+    return True, models, None
+
+
+def doctor(api_base: str, model: str, check_lmstudio: bool) -> dict[str, Any]:
+    checks: dict[str, Any] = {
+        "python": sys.executable,
+        "dependencies": {
+            "docling": has_module("docling"),
+            "pdf2image": has_module("pdf2image"),
+            "PIL": has_module("PIL"),
+            "requests": has_module("requests"),
+        },
+        "lmstudio": {
+            "checked": check_lmstudio,
+            "api_base": normalize_api_base(api_base),
+            "target_model": model,
+        },
+    }
+
+    if check_lmstudio:
+        ok, models, error = lmstudio_models(api_base)
+        checks["lmstudio"].update(
+            {
+                "available": ok,
+                "models": models,
+                "target_model_loaded": model in models,
+                "error": error,
+            }
+        )
+    return checks
+
+
+def require_pdf(path_text: str) -> Path:
+    pdf_path = Path(path_text).expanduser()
+    if not pdf_path.exists():
+        raise CliError(f"PDF not found: {pdf_path}")
+    if not pdf_path.is_file():
+        raise CliError(f"PDF path is not a file: {pdf_path}")
+    return pdf_path
+
+
+def emit_result(result: dict[str, Any], output_format: str) -> None:
+    if output_format == "json":
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+        return
+    for key, value in result.items():
+        print(f"{key}: {value}")
+
+
+def add_common_convert_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("pdf", help="Input PDF path")
+    parser.add_argument("--output", help="Output Markdown path")
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+
+
+def add_vlm_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--api-base", default=DEFAULT_API_BASE, help="LM Studio OpenAI-compatible API base")
+    parser.add_argument("--model", default=DEFAULT_MODEL, help="LM Studio model id")
+    parser.add_argument("--dpi", type=int, default=DEFAULT_DPI, help="PDF render DPI")
+    parser.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT, help="LM Studio request timeout seconds")
+    parser.add_argument("--start-page", type=int, default=1, help="First page to process, 1-indexed")
+    parser.add_argument("--end-page", type=int, default=None, help="Last page to process, 1-indexed")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Convert PDF files to Markdown for AI workflows")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    doctor_parser = subparsers.add_parser("doctor", help="Check local dependencies and optional LM Studio availability")
+    doctor_parser.add_argument("--api-base", default=DEFAULT_API_BASE)
+    doctor_parser.add_argument("--model", default=DEFAULT_MODEL)
+    doctor_parser.add_argument("--check-lmstudio", action="store_true")
+    doctor_parser.add_argument("--format", choices=["text", "json"], default="text")
+
+    docling_parser = subparsers.add_parser("docling", help="Convert with Docling")
+    add_common_convert_args(docling_parser)
+
+    vlm_parser = subparsers.add_parser("vlm-ocr", help="OCR with LM Studio vision model")
+    add_common_convert_args(vlm_parser)
+    add_vlm_args(vlm_parser)
+
+    convert_parser = subparsers.add_parser("convert", help="Convert with selected engine")
+    add_common_convert_args(convert_parser)
+    convert_parser.add_argument("--engine", choices=["docling", "vlm"], default="docling")
+    add_vlm_args(convert_parser)
+
+    return parser
+
+
+def run(args: argparse.Namespace) -> dict[str, Any]:
+    if args.command == "doctor":
+        return doctor(args.api_base, args.model, args.check_lmstudio)
+
+    pdf_path = require_pdf(args.pdf)
+    output_path = Path(args.output).expanduser() if args.output else default_output_path(pdf_path)
+
+    engine = args.command
+    if args.command == "convert":
+        engine = args.engine
+
+    if engine == "docling":
+        markdown = convert_with_docling(pdf_path)
+    elif engine == "vlm-ocr" or engine == "vlm":
+        markdown = convert_with_vlm(
+            pdf_path=pdf_path,
+            api_base=args.api_base,
+            model=args.model,
+            dpi=args.dpi,
+            timeout=args.timeout,
+            start_page=args.start_page,
+            end_page=args.end_page,
+        )
+    else:  # pragma: no cover - argparse prevents this
+        raise CliError(f"Unsupported engine: {engine}")
+
+    write_text(output_path, markdown)
+    return {
+        "input": str(pdf_path),
+        "output": str(output_path),
+        "engine": engine,
+        "chars": len(markdown),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        result = run(args)
+    except CliError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    emit_result(result, getattr(args, "format", "text"))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/rules/skills/tests/test_pdf_to_markdown_cli.py
+++ b/rules/skills/tests/test_pdf_to_markdown_cli.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+from rules.skills import pdf_to_markdown_cli as cli
+
+
+def test_extract_message_text_prefers_content() -> None:
+    data = {"choices": [{"message": {"content": "hello", "reasoning_content": "hidden"}}]}
+
+    assert cli.extract_message_text(data) == "hello"
+
+
+def test_extract_message_text_falls_back_to_reasoning_content() -> None:
+    data = {"choices": [{"message": {"content": "", "reasoning_content": "ocr text"}}]}
+
+    assert cli.extract_message_text(data) == "ocr text"
+
+
+def test_extract_message_text_reads_list_content() -> None:
+    data = {"choices": [{"message": {"content": [{"text": "a"}, {"text": "b"}]}}]}
+
+    assert cli.extract_message_text(data) == "ab"
+
+
+def test_extract_message_text_errors_on_empty_response() -> None:
+    with pytest.raises(cli.CliError):
+        cli.extract_message_text({"choices": [{"message": {"content": ""}}]})
+
+
+def test_validate_page_range_rejects_invalid_values() -> None:
+    with pytest.raises(cli.CliError):
+        cli.validate_page_range(0, None)
+    with pytest.raises(cli.CliError):
+        cli.validate_page_range(3, 2)
+
+
+def test_build_vlm_payload_contains_image_and_prompt() -> None:
+    payload = cli.build_vlm_payload("abc123", "model-x")
+
+    assert payload["model"] == "model-x"
+    content = payload["messages"][1]["content"]
+    assert content[0]["image_url"]["url"] == "data:image/jpeg;base64,abc123"
+    assert content[1]["text"] == cli.OCR_USER_PROMPT
+
+
+def test_run_docling_writes_output(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    pdf_path = tmp_path / "input.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4\n")
+    output_path = tmp_path / "output.md"
+
+    monkeypatch.setattr(cli, "convert_with_docling", lambda path: f"converted {path.name}")
+    args = argparse.Namespace(command="docling", pdf=str(pdf_path), output=str(output_path), format="json")
+
+    result = cli.run(args)
+
+    assert output_path.read_text(encoding="utf-8") == "converted input.pdf"
+    assert result["engine"] == "docling"
+    assert result["chars"] == len("converted input.pdf")
+
+
+def test_run_vlm_uses_page_range(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    pdf_path = tmp_path / "input.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4\n")
+    output_path = tmp_path / "output.md"
+    captured = {}
+
+    def fake_convert_with_vlm(**kwargs):
+        captured.update(kwargs)
+        return "vlm text"
+
+    monkeypatch.setattr(cli, "convert_with_vlm", fake_convert_with_vlm)
+    args = argparse.Namespace(
+        command="vlm-ocr",
+        pdf=str(pdf_path),
+        output=str(output_path),
+        format="json",
+        api_base="http://localhost:1234/v1/",
+        model="model-y",
+        dpi=150,
+        timeout=12,
+        start_page=2,
+        end_page=4,
+    )
+
+    result = cli.run(args)
+
+    assert output_path.read_text(encoding="utf-8") == "vlm text"
+    assert result["engine"] == "vlm-ocr"
+    assert captured["start_page"] == 2
+    assert captured["end_page"] == 4
+    assert captured["dpi"] == 150
+
+
+def test_doctor_reports_dependency_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cli, "has_module", lambda name: name == "requests")
+
+    result = cli.doctor(cli.DEFAULT_API_BASE, cli.DEFAULT_MODEL, check_lmstudio=False)
+
+    assert result["dependencies"]["requests"] is True
+    assert result["dependencies"]["docling"] is False
+    assert result["lmstudio"]["checked"] is False


### PR DESCRIPTION
## Summary
- Add a reusable PDF to Markdown CLI with Docling and LM Studio VLM OCR commands.
- Document doctor, dependency setup, Docling path, VLM OCR fallback, and validation expectations.
- Add offline unit tests for CLI parsing, output writing, response extraction, and doctor dependency reporting.

## Validation
- `source .venv/bin/activate && python -m pytest -q rules/skills/tests/test_pdf_to_markdown_cli.py`
- `source .venv/bin/activate && python rules/skills/pdf_to_markdown_cli.py doctor --format json`
- Privacy grep over PDF CLI/test/docs for private paths and personal finance terms returned no matches.