### PR TITLE
Route delayed agent jobs to skill ecosystem

### DIFF
--- a/docs/SKILL_ECOSYSTEM.md
+++ b/docs/SKILL_ECOSYSTEM.md
@@ -26,8 +26,8 @@ Start from my workspace AGENTS.md or CLAUDE.md. Follow any WORKSPACE.md or skill
 | Email | [outlook_skill](https://github.com/grapeot/outlook_skill) | Outlook.com 邮件下载、归档、Markdown 渲染、发送和日历邀请 |
 | Email | [resend_email_skill](https://github.com/grapeot/resend_email_skill) | Resend 自定义域名发信、收件读取、Markdown 导出和附件检查 |
 | Messaging | [imessage_skill](https://github.com/grapeot/imessage_skill) | macOS iMessage send-only CLI；联系人 alias 放本地 overlay |
-| Agent operations | [opencode_skill](https://github.com/grapeot/opencode_skill) | OpenCode job 提交、批量任务、SQLite 数据维护和 archive |
-| Agent operations | [process-launcher](https://github.com/grapeot/process-launcher) | 本地 HTTP process launcher，适合 TCC / GUI 权限桥接 |
+| Agent operations | [opencode_skill](https://github.com/grapeot/opencode_skill) | OpenCode `submit` / `submit --dry-run` / batch submission、recurring cron workflow、SQLite 数据维护和 archive |
+| Agent operations | [process-launcher](https://github.com/grapeot/process-launcher) | 本地 HTTP process launcher，适合 TCC / GUI 权限桥接、durable one-shot delayed jobs、进程日志和取消 |
 | Usage analytics | [ai_usage_dashboard](https://github.com/grapeot/ai_usage_dashboard) | 多平台 AI token usage、成本估算、本地 dashboard 和 E1002 JSON |
 | Social / growth | [typefully-twitter-skill](https://github.com/grapeot/typefully-twitter-skill) | Typefully 发帖、账号指标和 X/Twitter 单帖 analytics |
 | Payments / growth | [stripe-skill](https://github.com/grapeot/stripe-skill) | Stripe 只读 finance / sales analytics，live tests 默认 opt-in |

--- a/rules/skills/INDEX.md
+++ b/rules/skills/INDEX.md
@@ -20,7 +20,7 @@
 - ⚙️ Share Report — 需要 SSH 服务器或 GitHub Pages
 - ⚙️ Google Docs — 需要 Google OAuth
 - ⚙️ Send Email — 需要 Gmail App Password
-- ⚙️ Delayed Execution — 适配你自己的工具路径
+- ⚙️ Delayed Execution — starter fallback；durable/AI 延时任务安装 Process Launcher + OpenCode Skill
 
 ### Tier 3: 独立 public skill repos（按需安装）
 - 🔧 图片生成、Tavily、Google Docs、Outlook、Resend、OpenCode、Process Launcher、PPTX、Typefully、Stripe 等能力见 [`docs/SKILL_ECOSYSTEM.md`](../../docs/SKILL_ECOSYSTEM.md)
@@ -65,7 +65,7 @@
 - [语义搜索技能](./semantic_search.md) ⚙️ — 利用向量相似度检索深层背景与观点演变
 - [知识飞轮设计模式](./workflow_knowledge_flywheel.md) — 笨数据+笨方法+笨模型=精知识
 - [视频下载与语音识别工作流](./workflow_bilibili_whisper_transcription.md) — Bilibili/YouTube 视频处理
-- [延时执行技能](./delayed_execution.md) ⚙️ — 定时任务：sleep + 后台执行，或 OpenCode API 智能任务
+- [延时执行技能](./delayed_execution.md) ⚙️ — 低风险 `sleep + nohup` fallback；durable/AI 延时任务见 ecosystem 的 Process Launcher + OpenCode Skill
 - [项目脚手架与重整](./project_scaffold.md) ✅ — 把散装目录升级成标准项目结构：`docs/`、`src/`、`scripts/`、`tests/`、`AGENTS.md` 与独立 git
 
 ### BestPractice（最佳实践）

--- a/rules/skills/delayed_execution.md
+++ b/rules/skills/delayed_execution.md
@@ -1,42 +1,30 @@
 # Skill: Delayed Execution (延时执行)
 
-用于在指定时间后执行任务，支持两种模式：命令行任务和智能任务。
+用于在一段时间后执行任务。这个 starter skill 只保留轻量 fallback；如果任务需要持久化、重启恢复、日志查询、取消、或提交 AI agent 工作，请安装 `docs/SKILL_ECOSYSTEM.md` 里的 public repos。
 
 ## When to Use
-- 需要在一段时间后执行某个操作（如检查 DNS 传播、发送提醒）
-- 定时任务但不想用 crontab
 
-## 模式 1：命令行延时任务
+- 需要在一段时间后执行一个简单命令
+- 当前 workspace 尚未安装更完整的 process manager
+- 任务丢失风险可接受
 
-适用于简单的命令行操作，用 `sleep` + 后台执行：
+## 推荐路径
 
-```bash
-# 语法：(sleep <秒数> && <命令>) &
-# 注意：整个命令用括号包起来放到后台，避免超时
+优先安装并使用 ecosystem 里的专用能力：
 
-# 示例：2小时后检查 DNS 并发邮件
-(sleep 7200 && python3 tools/<your-notify-script>.py "DNS Check Result" "$(dig TXT <your-domain> +short)") &
+- `process-launcher`: durable one-shot schedule、进程日志、取消、重启恢复
+- `opencode_skill`: OpenCode `submit` / `submit --dry-run` / batch submission
 
-# 示例：1小时后执行某个脚本
-(sleep 3600 && /path/to/script.sh) &
+对于需要 AI 判断的延时任务，正确组合是：先用 `opencode_skill submit --dry-run` 预检提交链路，再用 `process-launcher` 在未来时间触发真实 `opencode_skill submit`。不要在本 starter skill 里维护私有 OpenCode endpoint、模型、agent 或本地路径。
 
-# 查看后台任务
-jobs
+## 轻量 Fallback：sleep + nohup
 
-# 注意：后台任务会在 shell 关闭后终止，如需持久化用 nohup
-nohup bash -c "sleep 7200 && python3 tools/<your-notify-script>.py 'Subject' 'Body'" &
-```
-
-## 模式 2：智能延时任务（OpenCode Agent）
-
-适用于需要 AI 判断的复杂任务，通过 OpenCode API 提交：
+只适合低风险、短期、可丢失的命令行任务。
 
 ```bash
-# 使用 --no-wait 让任务异步执行
-# 在 prompt 中明确说明"在 X 时间后执行"（需要外部触发）
-
-# 实际延时需要配合模式 1 触发：
-(sleep 7200 && python3 tools/opencode_job.py "检查 DNS 记录 <your-domain> 和 <your-domain> 是否已传播完成，如果完成则发邮件通知 <your-email>" --title "DNS Check & Notify" --no-wait) &
+# 语法：nohup bash -c 'sleep <秒数> && <命令>' > /tmp/delayed_task.log 2>&1 &
+nohup bash -c 'sleep 3600 && /path/to/script.sh' > /tmp/delayed_task.log 2>&1 &
+disown
 ```
 
 ## 时间换算
@@ -51,58 +39,22 @@ nohup bash -c "sleep 7200 && python3 tools/<your-notify-script>.py 'Subject' 'Bo
 | 2 小时 | 7200 |
 | 24 小时 | 86400 |
 
-## Best Practices
-
-### 始终使用日志重定向
-
-**关键**：延时任务必须重定向输出到日志文件，否则无法调试问题。
-
-```bash
-# 标准格式：nohup + disown + 日志重定向
-nohup bash -c 'sleep 7200 && cd /path/to/your/workspace && python3 tools/opencode_job.py "任务描述" --title "Task Name" --no-wait' > /tmp/delayed_task.log 2>&1 &
-disown
-
-# 说明：
-# - nohup: 忽略 SIGHUP，shell 关闭后进程不终止
-# - > /tmp/xxx.log 2>&1: stdout 和 stderr 都重定向到日志
-# - &: 后台运行
-# - disown: 从 shell 的 job list 移除，彻底独立
-```
-
-### 日志文件命名约定
-
-```bash
-# 推荐格式：/tmp/delayed_<task_name>.log
-/tmp/dns_check_task.log
-/tmp/email_notify.log
-/tmp/cleanup_job.log
-```
-
-### 查看任务状态和日志
+## 查看与取消
 
 ```bash
 # 检查任务是否在运行
 ps aux | grep "sleep" | grep -v grep
 
-# 实时查看日志
+# 查看日志
 tail -f /tmp/delayed_task.log
 
-# 查看完整日志
-cat /tmp/delayed_task.log
-```
-
-### 取消延时任务
-
-```bash
-# 找到进程 PID
-ps aux | grep "sleep 7200" | grep -v grep
-
-# 杀掉进程
+# 取消任务
 kill <PID>
 ```
 
-## 注意事项
-- **必须**使用 `nohup` + `disown` 确保进程持久化
-- **必须**重定向输出到日志文件，方便调试
-- 长时间任务（>1天）建议用 crontab
-- OpenCode 任务适合需要 AI 判断的复杂场景
+## Safety Rules
+
+- 优先使用 `process-launcher`，除非任务确实低风险且可丢失。
+- 延时执行前先跑目标命令的 dry-run / check / preview 模式；没有预检能力时明确告知风险。
+- 所有 fallback 任务都必须重定向日志。
+- 不要把真实 API key、私有 endpoint、联系人、模型偏好或本机路径写进 public starter skill。


### PR DESCRIPTION
## Summary
- Move delayed AI job guidance out of the starter skill and into the public skill ecosystem model.
- Update `SKILL_ECOSYSTEM.md` to describe `opencode_skill` and `process-launcher` as the recommended durable delayed-agent combination.
- Keep `delayed_execution.md` as a low-risk `sleep + nohup` fallback only.

## Tests
- Docs-only change; not run.