### PR TITLE
docs: link English reference repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Context Infrastructure — Reference Implementation
 
+> English version: [https://github.com/grapeot/context-infrastructure-en](https://github.com/grapeot/context-infrastructure-en)
+>
 > 背景阅读：[为什么AI只会说正确的废话，以及怎么把它逼出舒适区](https://yage.ai/context-infrastructure.html)
 
 这是一个运行了一年的 context infrastructure 系统的完整结构。主要价值是作为 reference implementation，让你看到系统长什么样、数据如何流动、记忆如何积累。


### PR DESCRIPTION
Adds a link from the Chinese README to the English reference implementation at https://github.com/grapeot/context-infrastructure-en.