### PR TITLE
docs(skills): add Claude Code, iOS UI Automation, and Academic Paper conversion skills

### DIFF
--- a/rules/skills/INDEX.md
+++ b/rules/skills/INDEX.md
@@ -43,6 +43,7 @@
 调用外部系统或工具的操作手册。
 
 - [AI CLI Agent 实用指南](./ai_agent_cli_guide.md) — CLI Agent 设计原则、工具对比（Claude Code / Codex / OpenCode）、文件响应模式、AI 调用 AI
+- [Claude Code 使用指南](./claude_code.md) — Claude Code 的默认 runtime 设置（adaptive thinking 规避）、非交互命令行调用、嵌套调用硬规则及 Timeout 管理
 - [分享报告到 Web](./share_report.md) ⚙️ — 将 MD 报告转 HTML 发布到你自己的服务器，返回 URL
 - [Apple Compressor Skill](./compressor.md) ⚙️ — 本机 Apple Compressor CLI 转码；custom preset 路径、源文件写入完成检测、batch 提交与监控
 
@@ -69,6 +70,7 @@
 - [视频下载与语音识别工作流](./workflow_bilibili_whisper_transcription.md) — Bilibili/YouTube 视频处理
 - [延时执行技能](./delayed_execution.md) ⚙️ — 低风险 `sleep + nohup` fallback；durable/AI 延时任务见 ecosystem 的 Process Launcher + OpenCode Skill
 - [项目脚手架与重整](./project_scaffold.md) ✅ — 把散装目录升级成标准项目结构：`docs/`、`src/`、`scripts/`、`tests/`、`AGENTS.md` 与独立 git
+- [iOS UI 自动化测试工作流](./ios_ui_automation.md) — 基于 Xcode 模拟器、XCTest 与 simctl 的 iOS 界面及功能自动化验证指南
 
 ### BestPractice（最佳实践）
 
@@ -77,6 +79,7 @@
 - [AI 编程核心方法论](./bestpractice_ai_programming_mindset.md) ✅ — 70%问题、成功标准、可验证性
 - [Skill 写作指南（Meta-Skill）](./bestpractice_skill_writing.md) ✅ — 创建或重写 skill 时使用，强调结果确定性、验收标准和边界条件
 - [API Key 管理与调用](./bestpractice_api_key_management_1password_cli.md) ✅ — 使用 1Password CLI 安全管理密钥
+- [学术论文下载与格式转换](./bestpractice_academic_paper_conversion.md) ✅ — 基于 arXiv ID 检索、HTML/PDF 抓取并转化为 Markdown 的质量控制最佳实践
 - [面试评估框架](./bestpractice_interview_evaluation.md) ✅ — Trait > Skill、AI 作弊识别、技术深度探测
 - [Markdown 转 HTML 最佳实践](./bestpractice_markdown_html_conversion.md) ✅
 - [PDF 转 Markdown](./bestpractice_pdf_to_markdown.md) ✅ — 默认用 Docling，避免 PDF 场景下 MarkItDown / PyMuPDF4LLM / Marker 的质量或许可问题

--- a/rules/skills/bestpractice_academic_paper_conversion.md
+++ b/rules/skills/bestpractice_academic_paper_conversion.md
@@ -1,0 +1,175 @@
+# Skill: Download and Convert Academic Papers
+
+Best practices for downloading academic papers from arXiv and converting them to machine-readable markdown format.
+
+## When to Use
+
+- Building a paper corpus for a research project
+- Need to read paper content programmatically (LLM analysis, hypothesis generation, etc.)
+- Creating a local knowledge base from a researcher's publication list
+
+## Workflow Overview
+
+1. **Build a paper index** (`index.json`) with metadata
+2. **Find arXiv IDs** for papers that don't have them
+3. **Download and convert** to markdown (HTML preferred, PDF fallback)
+4. **Quality check** — verify correct paper downloaded, check for duplicates
+
+## Step 1: Build the Paper Index
+
+Start from the researcher's lab website publication page (most reliable) or Google Scholar. Create `index.json` with structured entries:
+
+```json
+{
+  "id": "P01",
+  "title": "Full paper title",
+  "authors": "Author1, Author2, ...",
+  "journal": "Journal Name Volume, Pages",
+  "year": 2024,
+  "arxiv_id": "2401.12345",
+  "role": "first_author",
+  "status": "pending"
+}
+```
+
+### Source priority for publication lists
+1. **Lab/group website** — curated, grouped by year, often has arXiv links
+2. **Google Scholar** — complete but may include papers where researcher is minor contributor
+3. **Semantic Scholar API** — programmatic access, good metadata
+
+### Pitfall: Google Scholar anti-scraping
+Google Scholar blocks automated scraping. Workarounds:
+- Ask the user to paste the page content directly
+- Use the browser extension if available
+- Use Semantic Scholar API as fallback
+
+## Step 2: Find arXiv IDs
+
+For papers without known arXiv IDs, search using Tavily:
+
+```bash
+cd adhoc_jobs/tavily_skill && .venv/bin/python -m tavily_skill search 'arXiv preprint "<exact paper title>"' \
+  --max-results 6 --answer advanced --stdout
+```
+
+### Key practices
+- Use the **exact paper title** in quotes — most reliable signal
+- Add `--answer advanced` to get Tavily's aggregated answer which often contains the arXiv ID
+- Do NOT use `--include-domain arxiv.org` — it over-restricts and misses results
+- Extract arXiv IDs with regex from both the answer and individual result URLs/content
+
+### Pitfall: Duplicate arXiv IDs
+After bulk searching, **always check for duplicate arXiv IDs** across papers:
+```python
+from collections import Counter
+ids = [p['arxiv_id'] for p in papers if p.get('arxiv_id')]
+dups = {k: v for k, v in Counter(ids).items() if v > 1}
+```
+Common causes of duplicates:
+- Search returns a related paper instead of the target (e.g., same material system, similar title)
+- A Nature Materials "News & Views" commentary gets matched to the original research paper's arXiv
+- Two papers in the same series get the same ID due to fuzzy matching
+
+### Pitfall: Wrong paper matched
+After finding an arXiv ID, consider verifying for critical papers:
+- Check the arXiv abstract page to confirm title and authors match
+- For HTML-available papers, the first few lines of extracted content reveal the actual title
+
+## Step 3: Download and Convert
+
+### Strategy: HTML first, PDF fallback
+
+**Check HTML availability:**
+```bash
+curl -sI "https://arxiv.org/html/{arxiv_id}" | head -1
+# HTTP/2 200 = HTML available
+# HTTP/2 404 = PDF only
+```
+
+**HTML path (preferred):** Use Tavily extract for clean markdown:
+```bash
+cd adhoc_jobs/tavily_skill && .venv/bin/python -m tavily_skill extract "https://arxiv.org/html/{arxiv_id}" \
+  --format markdown --stdout
+```
+Advantages: cleaner text, better equation rendering, proper section structure.
+
+**PDF path (fallback):** Download PDF then convert with markitdown:
+```bash
+curl -L -o raw/{id}_{arxiv_id}.pdf "https://arxiv.org/pdf/{arxiv_id}"
+```
+```python
+from markitdown import MarkItDown
+md = MarkItDown()
+result = md.convert('path/to/paper.pdf')
+```
+
+### File organization
+```
+contexts/papers/
+├── index.json              # Paper metadata index
+├── P01_1809.07437.md       # Converted markdown (with YAML frontmatter)
+├── P02_2105.06429.md
+├── ...
+└── raw/                    # Original PDFs (gitignored)
+    ├── P01_1809.07437.pdf
+    └── ...
+```
+
+### Naming convention
+- `{paper_id}_{arxiv_id}.md` — e.g., `P01_1809.07437.md`
+- Paper IDs use zero-padded two-digit numbers: P01, P02, ..., P49
+
+### YAML frontmatter
+Every markdown file starts with:
+```yaml
+---
+title: "Paper Title"
+arxiv_id: "2401.12345"
+authors: "Author1, Author2, ..."
+publication: "Journal Volume, Pages (Year)"
+year: 2024
+---
+```
+
+## Step 4: Quality Checks
+
+1. **File size check**: MD files should be >500 bytes (a few KB minimum for real papers)
+2. **Duplicate ID check**: Run after bulk arXiv ID search
+3. **Title verification**: For papers downloaded via arXiv ID search, spot-check that the downloaded content matches the expected paper
+4. **Content-header match**: After conversion, verify that the first few lines of the markdown body match the expected paper title. In practice, ~8% of auto-searched arXiv IDs were wrong, leading to completely unrelated papers being downloaded.
+5. **Rate limiting**: Add 1-second delay between arXiv downloads to be respectful
+
+### Critical: Wrong arXiv ID failure mode
+
+The most dangerous failure is downloading the correct file for a wrong arXiv ID — the PDF downloads successfully, converts to markdown without errors, and has a reasonable file size. The only way to catch this is by reading the content. In a batch workflow, the paper-reading agents serve as the last quality gate. When an agent reports a content mismatch, immediately:
+- Remove the wrong file
+- Set `arxiv_id: null` and `status: "wrong_arxiv_id"` in index.json
+- Do NOT retry with a different search — the paper may genuinely lack an arXiv preprint
+
+## Batch Processing Scripts
+
+The project includes two helper scripts in `scripts/`:
+- `search_arxiv_ids.py` — Bulk search for missing arXiv IDs via Tavily
+- `download_papers.py` — Bulk download and convert papers with arXiv IDs
+
+Both read/write `contexts/papers/index.json` and support `--only-missing` flag.
+
+## Papers Without arXiv Preprints
+
+Some papers won't have arXiv versions:
+- Journal-specific commentaries (Nature Materials "News & Views", etc.)
+- Very old papers predating arXiv adoption in the field
+- Some conference proceedings
+
+Mark these with `"status": "skip_no_preprint"` in index.json. If full text is still needed, check:
+- Publisher open access (some journals have delayed OA)
+- Author's institutional repository
+- DOI-based access through the user's institution
+
+## Lessons Learned
+
+1. **arXiv HTML is only available for newer papers** — roughly post-2023 submissions. Older papers are PDF-only.
+2. **markitdown works well for physics papers** — equations come through as LaTeX, figures are referenced, and section structure is preserved.
+3. **Tavily extract for HTML is very clean** — better than downloading raw HTML and parsing yourself.
+4. **The biggest time sink is arXiv ID discovery**, not download/conversion. Invest in good search queries upfront.
+5. **Always verify after bulk operations** — duplicate IDs and wrong-paper matches are the most common failure modes.

--- a/rules/skills/claude_code.md
+++ b/rules/skills/claude_code.md
@@ -1,0 +1,279 @@
+# Skill: Claude Code
+
+## 元数据
+- 类型: API Guide
+- 适用场景: 用 Claude Code CLI 做调研、改写、编辑文件、AI 调用 AI
+- 最后更新: 2026-04-08
+
+---
+
+## 什么时候用
+
+- 用户明确说用 Claude Code
+- 任务强依赖本地文件和 workspace 上下文
+- 需要非交互调用（`claude -p`）
+- 需要 Claude 自己去读 `AGENTS.md`、rules、skills、报告和目标文件并决定往下钻什么
+
+术语澄清：`Claude Code` = `claude` CLI / Claude Code 工具链。`Claude` = Anthropic 模型家族。**不要把"用 Claude Code"偷换成"用一个 Claude 路由的 subagent"**——后者只是一个底层可能用 Claude 模型的 agent，和 Claude Code CLI 是两回事。
+
+---
+
+## 默认 runtime 设置（必读）
+
+自 2026 年 2-3 月起，Claude Code 的 runtime 层默认值被悄悄调低过。Anthropic 在 2 月 9 日引入 adaptive thinking 机制（模型自己决定每个 turn 想多久），并在 3 月 3 日把默认 `effort` 从 `high` 调到 `medium` (=85)。adaptive thinking 被证明在某些 turn 上会把 reasoning token 分配到 0，Anthropic 团队在 HN 上亲口承认了这个 bug 但没有修复默认值。
+
+我们默认走两个 opt-in flag，让 Claude Code 始终按真正的 power-user 默认行为运行：
+
+1. **所有命令行调用一律带 `--effort max`**。把 session 的 reasoning 上限抬到最高。`--effort` 支持 `low/medium/high/max` 四档。
+2. **环境变量 `CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING=1`** 必须设置。禁止 adaptive thinking 在 ceiling 以下随机降级。这个变量已经 export 到 `~/.zshrc`，交互式 shell 自动继承；cron / subprocess / 不经 shell 的调用需要在子进程环境里显式传入（`env={**os.environ, "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING": "1"}`）。
+
+两件事是正交的：`--effort max` 抬上限，`CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING` 禁止上限以下随机降。必须两个一起做才有效。在 `effort=max` 前提下，单靠 `--effort max` 不能 work around adaptive thinking bug。
+
+本 skill 后续所有 example 命令都默认带 `--effort max`。如果 Anthropic 未来修复了默认值，我们会在这里 note 出来并回退；在那之前，不要省略。
+
+---
+
+## 默认模型
+
+Claude Code 一律用 `--model opus`。不做 Sonnet fallback，不基于 trivial 判断降级。
+
+---
+
+## 启动目录
+
+从工作区根目录启动。Claude Code 会沿着当前目录读取上下文，只有从 workspace 根启动才能稳定继承 `AGENTS.md`、`rules/SOUL.md`、`rules/USER.md`、`rules/WORKSPACE.md`、`rules/COMMUNICATION.md` 和 `rules/skills/INDEX.md`。
+
+- `workdir=$WORKSPACE_ROOT`
+- prompt 里尽量用绝对路径
+- 需要额外目录时用 `--add-dir`
+
+---
+
+## 非交互调用
+
+最小命令：
+
+```bash
+claude -p --model opus --effort max "your prompt"
+```
+
+拿 JSON 输出：
+
+```bash
+claude -p --model opus --effort max --output-format json "your prompt"
+```
+
+直接改文件（编辑型白名单）：
+
+```bash
+claude -p --model opus --effort max --permission-mode acceptEdits --tools Read,Edit,Write "your prompt"
+```
+
+直接进行调研（Claude 需要自己联网、跑 CLI、调用搜索引擎或 python 脚本）：
+
+```bash
+printf '%s' 'your research prompt' | claude -p --model opus --effort max \
+  --permission-mode acceptEdits --tools Bash,Read,Write
+```
+
+**工具白名单和任务类型必须匹配**：
+
+- `Read,Edit,Write` 适合文件改写
+- `Bash,Read,Write` 适合调研 + 落盘
+- research task 不要机械套用 `Read,Edit,Write`——没有 `Bash` 就等于没有检索能力
+
+**长 prompt 走 stdin**。如果 prompt 里有长文本和引号/撇号，stdin 比命令行参数更稳，避免 shell quoting 把 prompt 传坏。
+
+---
+
+## 调用层级规则（硬规则）
+
+**主 agent → subagent → `claude` CLI，最多两层。**
+
+- **主 agent 不得直接调用 `claude` CLI**。Claude Code (Opus) 调用耗时通常 2-10 分钟，直接在主线程跑会阻塞所有并行工作，而且会独占主 agent 的 Bash 会话。正确做法：通过后台 subagent 独立执行，让它在内部调用 `claude`。
+- **subagent 拿到任务后直接 Bash 执行 `claude -p`，禁止再派一层 agent**。不要调用嵌套派出机制。三层嵌套的失败模式是：外层 subagent 等内层 agent 回调，内层 agent 等 Claude Code 输出，任一层超时或消息丢失都会导致整个任务静默挂起。
+
+**主 agent 派出 subagent 时，prompt 必须包含这几条防递归声明**：
+
+1. "你是 subagent，不要再代理给其他 agent。"
+2. "直接用 Bash 调用 `claude -p --model opus --effort max`。prompt 走 stdin。环境变量 `CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING=1` 必须设置。"
+3. "这是分钟级长任务。Bash 工具的 timeout 设至少 600000ms（10 分钟），长文写作或深度调研给 900000ms（15 分钟）。"
+4. "返回可核验痕迹：实际调用命令、关键 stdout 或目标文件变更。不要只说'我改好了'。"
+
+**主 agent 必须做调用核验**。不能只看 subagent 的自述。通过可见证据确认它真的调用了 `claude` CLI（Bash 命令本身、stdout 结果、目标文件实际变更）。没看到证据就视为没有真正调用，必须回攻修正。
+
+分工逻辑是：便宜的 agent 做编排，Claude Code 做思考。
+
+---
+
+## 长任务 timeout
+
+Claude Code 调研、长文起草、重写、深度修订常见耗时 5-10 分钟，不能沿用 Bash 默认 120s timeout：
+
+- **长文起草 / 深度改写 / 复杂综合**：600000ms（10 分钟）起步
+- **重度调研 + 写作合并任务**：900000ms（15 分钟）
+- **subagent 内部调 `claude -p`**：交接 prompt 里显式写"长任务，超时预算至少 600-900 秒"
+
+按分钟级预算，不要按逆向小 shell 命令预算。
+
+---
+
+## Session continuity / resume
+
+Claude Code CLI 原生支持 session 持久化，不是把旧 prompt 再喂一遍。先区分三层概念：
+
+- **Dispatcher/Orchestrator 的 `session_id`**：外层 agent 的会话 ID，只延续其自身的上下文
+- **Claude Code CLI 的 session**：`claude` 自己持久化的对话历史，支持真正的 resume
+- **伪 continuity**：把 scratchpad、旧输出重新塞进 prompt。有用，但不等于 Claude Code 自己记住了对话
+
+**硬规则：不要把外层框架的 session_id 误当成 Claude Code 的 session，它们是两套独立系统。**
+
+CLI 支持的参数（来自 `claude --help`）：
+
+- `-c, --continue`：继续当前目录最近一次对话
+- `-r, --resume [value]`：按 session ID / 名称恢复
+- `--fork-session`：恢复时分叉成新 session ID
+- `--session-id <uuid>`：指定会话 ID
+- `--no-session-persistence`：禁止持久化（仅 `--print` 模式；用了之后不能 resume）
+
+常用用法：
+
+```bash
+# 继续当前目录最近一次对话
+claude -c --effort max
+
+# 恢复指定 session
+claude -r <session-id> --effort max -p "continue the previous analysis"
+
+# 恢复但分叉，保留原 session 不被覆盖
+claude -r <session-id> --fork-session --effort max -p "take a different direction"
+```
+
+适合用 resume 的场景：同一任务分多轮继续、上一轮被中断但需要保留对话历史、多轮修订明确依赖上一轮上下文。
+
+不适合的场景：单轮 `claude -p` 就能完成、要换方向而旧上下文会造成污染、外层 scratchpad 已经够用且保留旧历史徒增 token 成本。
+
+---
+
+## 调研模式：先给目标，不先给答案
+
+如果任务是调研，默认给 Claude Code 目标、边界、起点，**让它自己决定搜什么**：
+
+**要给的**：调研目标、成功标准、边界条件、起始文件或目录、可用工具（必须包含 `Bash`）
+
+**不要做的**：
+- 先替它搜一轮再把结果当成唯一语料塞进 prompt
+- 把大量预处理好的上下文直接塞进 prompt
+- 把 research task 偷换成 summary task
+- 把 Claude Code 降级成 writer-only 或 final drafting only
+
+只有两种情况适合先准备材料：数据源昂贵、受限或 Claude 无法直接访问；或你要的不是 full research 而是对一批已知材料做二次判断、筛选、写作。
+
+**如果 Claude Code 在分析或写作过程中发现论证盲点、证据缺口、概念边界不清，默认允许它做补充调研**。目标是 targeted gap-filling，不是重新发散做完整 research pass。
+
+**深度调研 / 观点碰撞 / 长文论证，默认让 Claude Code 做 lead thinker + final writer**，不是让它在主线程想完之后只负责措辞。
+
+原则：**能放文件里的知识不要塞进 prompt；能让 Claude 自己找到的信息不要先替它找**。
+
+---
+
+## 写作任务：用户反馈必须原样落盘
+
+如果任务涉及写作、重写、风格校准、标题修改、结构改写，包装层可以补充执行说明，但**必须把用户原始反馈 as-is 落到本地 handoff / scratchpad 文件里，再让 Claude Code 自己去读**。
+
+- **不要只把用户意思"转述"给 Claude Code**。原话必须作为独立文件保留。
+- 包装层只管执行约束（目标文件、边界、工具、超时、核验），不管写作风格。
+- 显式告诉 Claude Code：**按用户 handoff + `rules/COMMUNICATION.md` 写，不要被 prompt 文风带偏**。
+
+推荐流程：
+
+1. 从工作区根目录启动
+2. 把用户原始反馈原样写入 handoff 文件
+3. prompt 只写目标、边界、目标文件、语言继承、风格约束
+4. 让 Claude Code 自己读 `AGENTS.md`、rules、已有报告、handoff 和目标文档
+5. 直接编辑目标文件或输出到指定路径
+
+**语言继承是硬规则**。用户用中文，包装层 prompt 和 Claude Code 输出都用中文；用户用英文，全链路英文。不要依赖 Claude 自己判断语言——默认情况下模型经常会回落到英文。
+
+---
+
+## Final report protocol
+
+如果任务属于 research + writing workflow，目标是产出最终可复用报告，Claude Code 在执笔前必须完成一轮标准预读：
+
+1. `AGENTS.md`
+2. `rules/SOUL.md`
+3. `rules/USER.md`
+4. `rules/WORKSPACE.md`
+5. `rules/COMMUNICATION.md`
+6. `rules/skills/INDEX.md`
+7. 当前 session 的 scratchpad、manifest、search notes、目标报告文件
+
+---
+
+## 临时上下文文件
+
+如果确实要补充一次性上下文，先写入文件再让 Claude Code 去读：
+
+- 为每个 workflow/session 建独立子目录：`tmp/<session_slug>/`
+- 把 scratchpad、source manifest、search notes、claude brief、gap list 放同一目录
+- 关键中间产物默认落盘，不依赖 stdout
+- 文件名写清楚职责：`scratchpad.md`、`search_manifest.md`、`claude_brief.md`
+- 只有长期有复用价值才转正到 `contexts/` 或 `docs/`
+
+---
+
+## 参考实现
+
+生产脚本里的 canonical 模式：
+
+```python
+import os
+import subprocess
+
+result = subprocess.run(
+    ["claude", "-p", "--model", "opus", "--effort", "max", "--permission-mode", "acceptEdits"],
+    cwd=WORKSPACE_ROOT,
+    input=driver_prompt,
+    text=True,
+    capture_output=True,
+    check=False,
+    env={**os.environ, "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING": "1"},
+)
+```
+
+两个必须：`--effort max` 必传，`CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING=1` 必在 env 里。cron job 类非交互场景不要依赖 `~/.zshrc` 的 export，subprocess 不一定继承 login shell 环境。
+
+---
+
+## 实战 caveats
+
+1. `claude -p` 必须真收到 prompt，命令行参数或 stdin 都行，长 prompt 走 stdin 更稳
+2. 改文件时显式给 `--permission-mode acceptEdits`
+3. 用绝对路径减少路径歧义
+4. 包装层要处理 `FileNotFoundError`，给出 `claude` 不在 PATH 的清晰报错
+5. 对外部站点搜索要有超时意识：5-7 分钟为一个检查点，没产出就用已有证据推进
+6. Search manifest 要写清楚产出文件路径和 subagent 原始产出的回溯方式，否则后续只能看到判断看不到载体
+7. 任务如果不必同步等待结果，默认走后台 subagent，不要在主线程直接跑 `claude`
+
+---
+
+## 关键参数速查
+
+| 参数 | 默认 | 说明 |
+|---|---|---|
+| `--model` | `opus` | 一律用 Opus，不降级 |
+| `--effort` | `max` | **必传**，见「默认 runtime 设置」 |
+| `--output-format` | `text` | 可选 `json` / `stream-json` |
+| `--permission-mode` | — | 编辑任务用 `acceptEdits` |
+| `--tools` | — | 编辑用 `Read,Edit,Write`；调研用 `Bash,Read,Write` |
+| `--json-schema` | — | 强制结构化 JSON 输出 |
+| `-c` / `--continue` | — | 继续当前目录最近一次对话 |
+| `-r` / `--resume` | — | 按 session ID 恢复 |
+| `--fork-session` | — | resume 时分叉成新 session |
+
+## 关键环境变量
+
+| 变量 | 值 | 说明 |
+|---|---|---|
+| `CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING` | `1` | **必设**。禁用 adaptive thinking。已 export 到 `~/.zshrc`；cron/subprocess 需显式传入 |

--- a/rules/skills/ios_ui_automation.md
+++ b/rules/skills/ios_ui_automation.md
@@ -1,0 +1,112 @@
+# iOS UI Automation Skill
+
+## Metadata
+
+- Type: Workflow
+- Use when: an agent needs to validate ANY iOS app's UI with Xcode — building to a simulator, capturing screenshots, driving the app through XCTest click-throughs, and visually verifying the result.
+- Primary tools: `xcodebuild build` / `xcodebuild test`, `xcrun simctl`, XCTest UI tests, local screenshot inspection.
+- Artifact policy: screenshots and `.xcresult` bundles are local QA artifacts; do not commit them.
+
+This skill is **app-agnostic**. It describes the method; the per-app specifics (project path, scheme, bundle identifier, launch arguments, accessibility identifiers, and the flow that constitutes a passing run) are supplied by the caller. A project that uses this skill repeatedly should keep its own small "config" file enumerating those values and point back here for the method. (Example consumer config: `path/to/project/skills/ios_ui_automation_config.md`.)
+
+## Goal
+
+Produce reproducible evidence that an iOS app works visually and behaves correctly on a simulator, without exposing any private data (mail, endpoint URLs, bearer tokens, account names, local configuration). A successful run proves the relevant user flow through some combination of automated tests, targeted simulator interaction, screenshots, and an explicit read/verify pass over the captured UI state.
+
+This skill is equally useful for **pure visual verification** — e.g. "did this design change actually render the way I intended?" — where you build, launch in a deterministic state, screenshot the screen under review, and inspect the image. You do not always need full XCTest assertions; for a visual-only check, a deterministic launch plus a screenshot plus a careful read is enough.
+
+## Boundaries
+
+This skill validates the iOS app surface only. It does not mutate any production backend except when the caller explicitly asks for live testing and the flow uses synthetic data. Default to deterministic UI-test / fixture mode.
+
+Screenshots may contain visible private data. Keep them under an ignored path such as `tmp/visual_qa/`, inspect each capture before sharing, and never commit screenshots that show real user data, real endpoint URLs, tokens, or private account names.
+
+## Per-App Inputs (caller supplies these)
+
+Before running, gather the following for the target app. If the caller hasn't given them, discover them from the project (`xcodebuild -list`, the `.xcodeproj`, Info.plist) or ask:
+
+- **Xcode project / workspace path** — e.g. `path/to/App.xcodeproj`
+- **Scheme** — the buildable scheme name (`xcodebuild -list` enumerates them)
+- **Bundle identifier** — for `simctl launch` / `terminate`
+- **Simulator destination** — a `platform=iOS Simulator,name=<device>,OS=<version>` whose OS ≥ the app's deployment target
+- **Deterministic launch arguments** — any flags that put the app into a fixture / UI-test state with synthetic data (so screenshots are public-safe and reproducible). If the app has none, note that and use the app's normal cold-launch state.
+- **Accessibility identifiers** — the `tab.*` / `*.button` / `*.field` identifiers used to drive and assert the flow under review
+- **The passing flow** — the minimal sequence of screens/actions that, if correct, means this run passes
+
+A consumer project should freeze these into its own config file rather than rediscovering them each time.
+
+## Acceptance Criteria
+
+A UI automation run is complete when:
+
+- `xcodebuild build` (visual-only) or `xcodebuild test` (behavioral) exits 0 for the chosen destination.
+- For a behavioral run, the flow is covered with XCTest assertions or an equivalent deterministic click-through script.
+- Any manual `simctl` launch uses deterministic / fixture arguments unless live testing was explicitly requested.
+- Screenshots are captured for the screens under review and stored under `tmp/visual_qa/`.
+- Each screenshot is inspected after capture for both visual correctness and privacy.
+- The agent reports the simulator destination, the commands used, the screenshot paths, the test/build result, and any residual risk.
+
+## Automation Surfaces
+
+Use **XCTest UI tests** for repeatable interactions and rich assertions. They drive the app through accessibility identifiers that the caller supplies (e.g. `tab.<name>`, `<screen>.<control>`). Identifiers should be stable and semantic, not positional.
+
+Use **`simctl`** for app installation, deterministic launches, and screenshots. `simctl` cannot express rich UI assertions on its own, so it is best for visual evidence — either after XCTest has proved the flow, or as the primary tool for a visual-only design check.
+
+## Command Patterns
+
+Discover schemes:
+
+```bash
+xcodebuild -list -project "<project>"
+```
+
+Run the full test suite (behavioral):
+
+```bash
+xcodebuild test \
+  -project "<project>" \
+  -scheme "<scheme>" \
+  -destination 'platform=iOS Simulator,name=<device>,OS=<version>'
+```
+
+Build, install, launch deterministically, and capture a screenshot (visual-only):
+
+```bash
+xcodebuild build \
+  -project "<project>" \
+  -scheme "<scheme>" \
+  -destination 'platform=iOS Simulator,name=<device>,OS=<version>'
+
+# Resolve the actual built .app under DerivedData (globs don't expand inside quotes;
+# prefer the newest product from the build you just ran).
+xcrun simctl install "<device-uuid>" "<resolved-derived-data>/<App>.app"
+xcrun simctl launch "<device-uuid>" <bundle-id> <deterministic-launch-args>
+xcrun simctl io "<device-uuid>" screenshot "tmp/visual_qa/<screen>.png"
+```
+
+For full-page detail screenshots that exceed one viewport, prefer an in-test scroll-and-stitch helper over a single `io screenshot`, and consider a launch flag that hides the tab bar.
+
+## Read/Verify Loop
+
+After each screenshot, inspect the image before deciding the flow passed. The inspection should answer:
+
+- Is this the intended screen, or did launch/navigation land somewhere else?
+- Are the expected controls visible and enabled/disabled correctly?
+- Does the specific visual change / issue under review look right?
+- Does the screenshot contain only synthetic / public-safe data?
+- Is there any simulator/system alert blocking the app?
+
+If the answer is unclear, capture one more screen after a deterministic action rather than guessing from stale output.
+
+## Known Failure Modes
+
+- `App installation failed: Requires a Newer Version of iOS`: the selected simulator OS is below the deployment target. Pick a newer installed simulator. A booted simulator with an older OS is a bad target because install fails *after* the build already succeeded.
+- `simctl screenshot` fails or prints usage: use `xcrun simctl io <device> screenshot <path>`. Recent Xcode versions route screenshots through `io`.
+- Screenshot shows stale UI: terminate the app, reinstall the freshly built `.app`, relaunch with the deterministic arguments, and wait briefly before capture.
+- UI test fails to launch an xctrunner once but the final result still says `TEST SUCCEEDED`: trust the final `xcodebuild` result and the test-case list, but rerun if the failed launch corresponds to the specific flow under review.
+- Standalone SourceKit diagnostics report `No such module Testing` / `No such module XCTest`: use a target-aware `xcodebuild test` as the source of truth for test files, not standalone diagnostics.
+- Screenshot contains real user data / real config: discard it, relaunch in deterministic/fixture mode, and do not share or commit the artifact.
+
+## Live Testing
+
+Live API testing is a separate mode. It may use a real backend only with synthetic data and explicit live-test arguments/environment. Do not capture screens that show real tokens or real user content; use tests or scripts that assert status and IDs without dumping sensitive bodies.


### PR DESCRIPTION
Imports and anonymizes three valuable generic skills from private workspace: Claude Code runtime/timeout practices, iOS simulator UI automation workflow, and arXiv academic paper download & markdown conversion checklist.