### PR TITLE
Add AI session search and archive workflow

### DIFF
--- a/docs/CRONTAB.md
+++ b/docs/CRONTAB.md
@@ -22,6 +22,17 @@ Daily     → Crontab Monitor: 健康审计，发现异常则发告警邮件
 
 ## 核心任务说明
 
+### Session Sync（每日）
+
+使用独立的 [ai_session_export](https://github.com/grapeot/ai_session_export)
+把 OpenCode、Claude Code、Codex、Antigravity 和 Second Mind 的本地会话增量导出为
+统一 Markdown。真实归档应放在私有数据目录并加入 `.gitignore`，不要写进 public repo。
+
+- **建议时间**：每日 4:00 AM
+- **输出**：`contexts/ai_sessions/<source>/`
+- **可选后处理**：用 semantic-search-skill 刷新私有向量索引
+- **搜索入口**：`rules/skills/ai_session_search_archive.md`
+
 ### AI Heartbeat Observer（每日）
 
 扫描 workspace 文件变动，提取有价值的观察写入 `contexts/memory/OBSERVATIONS.md`。这是三层记忆系统的"输入端"。
@@ -67,6 +78,9 @@ Daily     → Crontab Monitor: 健康审计，发现异常则发告警邮件
 
 # AI Heartbeat Observer — 每日 8:00 AM
 0 8 * * * cd /path/to/your/workspace && /path/to/your/workspace/.venv/bin/python periodic_jobs/ai_heartbeat/src/v0/observer.py >> /tmp/observer.log 2>&1
+
+# Session Sync — 每日 4:00 AM；先按 ai_session_export README 配置私有输出路径
+0 4 * * * cd /path/to/ai_session_export && /path/to/ai_session_export/.venv/bin/python export_sessions.py --base-dir /path/to/your/workspace/contexts/ai_sessions --state-file /path/to/your/workspace/contexts/ai_sessions/.export_state.json >> /tmp/ai_session_sync.log 2>&1
 
 # AI Heartbeat Reflector — 每周日 9:00 AM
 0 9 * * 0 cd /path/to/your/workspace && /path/to/your/workspace/.venv/bin/python periodic_jobs/ai_heartbeat/src/v0/reflector.py >> /tmp/reflector.log 2>&1

--- a/docs/SKILL_ECOSYSTEM.md
+++ b/docs/SKILL_ECOSYSTEM.md
@@ -29,6 +29,7 @@ Start from my workspace AGENTS.md or CLAUDE.md. Follow any WORKSPACE.md or skill
 | Email / newsletter | [kit-skill](https://github.com/grapeot/kit-skill) | Kit Broadcast Markdown 发信 CLI，支持 dry-run、draft-only、web-only 和 tag/segment 定向；账号默认值放本地 overlay |
 | Messaging | [imessage_skill](https://github.com/grapeot/imessage_skill) | macOS iMessage send-only CLI；联系人 alias 放本地 overlay |
 | Agent operations | [opencode_skill](https://github.com/grapeot/opencode_skill) | OpenCode `submit` / `submit --dry-run` / batch submission、recurring cron workflow、SQLite 数据维护和 archive |
+| Agent operations | [ai_session_export](https://github.com/grapeot/ai_session_export) | 将 OpenCode、Claude Code、Codex、Antigravity 和 Second Mind 会话增量导出为统一 Markdown 归档，供浏览和检索 |
 | Agent operations | [process-launcher](https://github.com/grapeot/process-launcher) | 本地 HTTP process launcher，适合 TCC / GUI 权限桥接、durable one-shot delayed jobs、进程日志 and 取消 |
 | Agent operations | [opencode-docker](https://github.com/grapeot/opencode-docker) | Docker 部署模版，用于快速配置 OpenCode Server 容器化运行环境 |
 | Usage analytics | [ai_usage_dashboard](https://github.com/grapeot/ai_usage_dashboard) | 多平台 AI token usage、成本估算、本地 dashboard 和 E1002 JSON |

--- a/docs/working.md
+++ b/docs/working.md
@@ -1,5 +1,11 @@
 # Working Log
 
+## 2026-07-15
+
+- Added a public AI Session Search & Archive workflow with source routing, lexical-first retrieval, fresh semantic-search file lists, freshness checks, and privacy-safe result rules.
+- Added `ai_session_export` to the public ecosystem and documented a daily multi-source Session Sync covering OpenCode, Claude Code, Codex, Antigravity, and Second Mind.
+- Added the private `contexts/ai_sessions/<source>/` route to the starter workspace map.
+
 ## 2026-07-12
 
 - Added `genai_portrait_skill` to the public skill ecosystem for identity-preserving portrait, headshot, and ID-photo editing with photographic coherence.

--- a/rules/WORKSPACE.md
+++ b/rules/WORKSPACE.md
@@ -13,6 +13,7 @@
 - 通用调研报告：`contexts/survey_sessions/`
 - 思考 / 复盘 / 方法论：`contexts/thought_review/`
 - 每日日志：`contexts/daily_records/`
+- AI 会话归档：`contexts/ai_sessions/<source>/`（使用 ai_session_export 生成；搜索流程见 `rules/skills/ai_session_search_archive.md`）
 
 ### 系统与规则
 - 可复用技术方案 / Skill：`rules/skills/`

--- a/rules/skills/INDEX.md
+++ b/rules/skills/INDEX.md
@@ -27,7 +27,7 @@
 - ⚙️ Delayed Execution — starter fallback；durable/AI 延时任务安装 Process Launcher + OpenCode Skill
 
 ### Tier 3: 独立 public skill repos（按需安装）
-- 🔧 图片生成、Tavily、Google Docs、Google Maps、Outlook、Resend、OpenCode、Process Launcher、PPTX、Typefully、Circle Post、Stripe、Firewalla、Smart Home 等能力见 [`docs/SKILL_ECOSYSTEM.md`](../../docs/SKILL_ECOSYSTEM.md)
+- 🔧 AI Session Export、图片生成、Tavily、Google Docs、Google Maps、Outlook、Resend、OpenCode、Process Launcher、PPTX、Typefully、Circle Post、Stripe、Firewalla、Smart Home 等能力见 [`docs/SKILL_ECOSYSTEM.md`](../../docs/SKILL_ECOSYSTEM.md)
 
 ### 说明
 ✅ = 最多 15 分钟即可使用
@@ -71,6 +71,7 @@
 - [视频下载与语音识别工作流](./workflow_bilibili_whisper_transcription.md) — Bilibili/YouTube 视频处理
 - [延时执行技能](./delayed_execution.md) ⚙️ — 低风险 `sleep + nohup` fallback；durable/AI 延时任务见 ecosystem 的 Process Launcher + OpenCode Skill
 - [项目脚手架与重整](./project_scaffold.md) ✅ — 把散装目录升级成标准项目结构：`docs/`、`src/`、`scripts/`、`tests/`、`AGENTS.md` 与独立 git
+- [AI Session Search & Archive](./ai_session_search_archive.md) — 在 OpenCode、Claude Code、Codex、Antigravity 与 Second Mind 的统一 Markdown 归档中按来源检索；named entity 先走 lexical search，模糊记忆再走 semantic search
 - [iOS UI 自动化测试工作流](./ios_ui_automation.md) — 基于 Xcode 模拟器、XCTest 与 simctl 的 iOS 界面及功能自动化验证指南
 
 ### BestPractice（最佳实践）

--- a/rules/skills/ai_session_search_archive.md
+++ b/rules/skills/ai_session_search_archive.md
@@ -1,0 +1,96 @@
+# AI Session Search & Archive
+
+## Objective
+
+Find prior AI sessions across a unified Markdown archive without depending on a
+single vendor's history UI. Use lexical search for names and identifiers, then
+semantic search when the remembered wording is approximate.
+
+This workflow assumes an archive produced by a multi-source exporter such as
+[ai_session_export](https://github.com/grapeot/ai_session_export). Keep the
+archive private: session titles, transcripts, project paths, and identifiers
+may all contain sensitive information.
+
+## Source Routing
+
+A typical archive has one directory per source:
+
+```text
+contexts/ai_sessions/
+  opencode/
+  claude_code/
+  codex/
+  antigravity/
+  second_mind/
+```
+
+- When the user names a source, search only that directory.
+- When the source is unknown, search every available source directory.
+- Generate client-specific action links only when the result metadata and host
+  explicitly support them. Otherwise return an ordinary Markdown file link.
+
+## Retrieval Order
+
+### 1. Lexical search for named entities
+
+Product names, people, projects, titles, dates, and session ids should use
+`rg` first. Expand a remembered name into a few plausible variants rather than
+assuming the user's wording exactly matches the archived title.
+
+```bash
+rg -i -n --glob '*.md' \
+  'Claude Teacher|Claude for Teachers|Anthropic for Teachers' \
+  contexts/ai_sessions/{opencode,claude_code,codex,antigravity,second_mind}/
+```
+
+Glob searches filenames, not file contents. A truncated glob result is not
+evidence that no matching session exists.
+
+### 2. Semantic search for approximate memories
+
+Generate the file list from the current source scope at query time. Do not
+reuse an old `tmp/*files*.txt`: a semantic-search file list is also a result
+allowlist, so an omitted file cannot be returned even if its vectors exist in
+the cache.
+
+```bash
+FILELIST="$(mktemp)"
+trap 'rm -f "$FILELIST"' EXIT
+rg --files contexts/ai_sessions/{opencode,claude_code,codex,antigravity,second_mind}/ \
+  -g '*.md' > "$FILELIST"
+
+semantic-search query \
+  --file-list "$FILELIST" \
+  --cache-dir .knowledge_cache \
+  --query 'the remembered concept' \
+  --top-k 10 \
+  --no-refresh
+```
+
+Use the installed semantic-search skill's provider and model configuration.
+Index refresh is a separate maintenance action; a read-only lookup should not
+silently rebuild a large shared cache.
+
+## Freshness Fallback
+
+Check the exporter's state or sync log before reading native stores. If the
+target session predates the latest successful source export, search the
+archive directly. Only perform a source-specific temporary export when the
+session is newer than the archive. Delete temporary exports after lookup.
+
+## Result Contract
+
+- Group chunks by source and session id so one session appears once.
+- Show title, date, source, project short name when available, and a verbatim
+  excerpt that lets the user verify the match.
+- Do not display embedding scores or replace evidence with an AI summary.
+- Read action ids from frontmatter; never infer them from filenames or text.
+- Do not put credentials, server addresses, local host profiles, absolute
+  archive paths, or user queries into action URLs.
+
+## Acceptance Criteria
+
+A session lookup is complete when the search covered the correct source scope,
+named-entity variants were tried before semantic fallback, semantic queries
+used a fresh scoped file list, duplicate chunks were consolidated, and every
+navigation action came from validated archive metadata.


### PR DESCRIPTION
## Summary
- add a public multi-source AI Session Search & Archive workflow
- route OpenCode, Claude Code, Codex, Antigravity, and Second Mind explicitly
- use lexical search for named entities and fresh scoped file lists for semantic fallback
- document ai_session_export daily sync and private archive boundaries

## Verification
- `git diff --check`
- privacy pattern review found no personal paths, credentials, private endpoints, real session ids, or transcript excerpts
- linked exporter: https://github.com/grapeot/ai_session_export

## Approval
- Functional/publication authorization: grapeot, explicitly requested in the originating session on 2026-07-15
- Privacy review: OpenCode agent, 2026-07-15, approved with no findings