### PR TITLE
docs: register scaffolded project routes

### DIFF
--- a/rules/WORKSPACE.md
+++ b/rules/WORKSPACE.md
@@ -32,3 +32,4 @@
 
 <!-- 随着你的项目增长，在这里添加活跃项目的快捷路由 -->
 <!-- 格式：- `project-name` → `adhoc_jobs/project_name/` (说明) -->
+<!-- 示例：- `weather monitor` / `weather_monitor` → `adhoc_jobs/weather_monitor/`（家庭气象数据采集与告警） -->

--- a/rules/skills/project_scaffold.md
+++ b/rules/skills/project_scaffold.md
@@ -201,6 +201,7 @@ project_root/
 3. 先写 `prd.md` / `rfc.md` / `test.md`
 4. 再把代码迁到 `src/`，把可执行入口放进 `scripts/`
 5. 最后补 `working.md`
+6. 在 `rules/WORKSPACE.md` 登记新项目的快捷路由。新增一行时同时写出读者会使用的别名、项目路径和一句用途，例如：`weather monitor` / `weather_monitor` → `adhoc_jobs/weather_monitor/`（家庭气象数据采集与告警）。
 
 不要一边大改代码一边临时想目录结构。先把骨架立起来，后面的改动才会更稳。
 


### PR DESCRIPTION
Adds a concrete WORKSPACE.md route example and makes route registration a required scaffolding step.