### PR TITLE
docs: add M5StickS3 skill to ecosystem

### DIFF
--- a/docs/SKILL_ECOSYSTEM.md
+++ b/docs/SKILL_ECOSYSTEM.md
@@ -60,6 +60,7 @@ Start from my workspace AGENTS.md or CLAUDE.md. Follow any WORKSPACE.md or skill
 | Design | [design_skill](https://github.com/grapeot/design_skill) | UI evaluation and improvement judgment framework |
 | Home automation | [smart_home_skill](https://github.com/grapeot/smart_home_skill) | Smart home CLI；device aliases and household details in local overlay |
 | E-ink display | [eink_diary](https://github.com/grapeot/eink_diary) | Visual diary generation for e-ink displays |
+| Embedded hardware | [m5stack-sticks3-skill](https://github.com/grapeot/m5stack-sticks3-skill) | M5StickS3 板级 bring-up 与实机验收指南；覆盖 Arduino/ESP-IDF、按钮、电源、LCD、IR、ES8311 音频、NVS 和 BLE HID 陷阱，不回显设备 secret |
 | Identity | [logto-management-skill](https://github.com/grapeot/logto-management-skill) | 安全发现、审计和管理 Logto 租户配置的 CLI + Python 库；支持租户 Swagger 检索、配置写入强制备份与回读校验、快照 diff、MFA 运维和破坏性操作 dry-run |
 
 ## 选择原则

--- a/docs/working.md
+++ b/docs/working.md
@@ -1,5 +1,9 @@
 # Working Log
 
+## 2026-07-29
+
+- Added `m5stack-sticks3-skill` to the public ecosystem for source-backed M5StickS3 board bring-up and hardware acceptance checks; it contains no workspace-private overlay or device secrets.
+
 ## 2026-07-20
 
 - Added `apple-photos-skill` for normalized Apple Photos metadata workflows and explicitly authorized, dry-run-first PhotoKit mutations; the public entry preserves its live-unverified alpha boundary.


### PR DESCRIPTION
Adds the public M5StickS3 board bring-up skill to the ecosystem index. The entry documents its Arduino/ESP-IDF hardware scope and secret-handling boundary.\n\nValidation: git diff --check; verified the public repository URL.